### PR TITLE
(fix) Use a php.ini file to set error_reporting level

### DIFF
--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -9,4 +9,5 @@ RUN docker-php-ext-install sysvsem
 RUN docker-php-ext-install sockets
 RUN docker-php-ext-install gd
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY php.ini /usr/local/etc/php/
 

--- a/7.0/php.ini
+++ b/7.0/php.ini
@@ -1,0 +1,2 @@
+error_reporting = E_ALL
+

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -9,4 +9,5 @@ RUN docker-php-ext-install sysvsem
 RUN docker-php-ext-install sockets
 RUN docker-php-ext-install gd
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY php.ini /usr/local/etc/php/
 

--- a/7.1/php.ini
+++ b/7.1/php.ini
@@ -1,0 +1,2 @@
+error_reporting = E_ALL
+

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -9,4 +9,5 @@ RUN docker-php-ext-install sysvsem
 RUN docker-php-ext-install sockets
 RUN docker-php-ext-install gd
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY php.ini /usr/local/etc/php/
 

--- a/7.2/php.ini
+++ b/7.2/php.ini
@@ -1,0 +1,2 @@
+error_reporting = E_ALL
+

--- a/generate.sh
+++ b/generate.sh
@@ -17,7 +17,10 @@ gen() {
   echo 'RUN docker-php-ext-install sockets' >> ${NAME}/Dockerfile
   echo 'RUN docker-php-ext-install gd' >> ${NAME}/Dockerfile
   echo 'RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer' >> ${NAME}/Dockerfile
+  echo 'COPY php.ini /usr/local/etc/php/' >> ${NAME}/Dockerfile
   echo '' >> ${NAME}/Dockerfile
+  echo 'error_reporting = E_ALL' > ${NAME}/php.ini
+  echo '' >> ${NAME}/php.ini
 }
 
 gen 7.0 7.0


### PR DESCRIPTION
Updates the generate script to add a `php.ini` file with `error_reporting` level set, then updates the generated files accordingly.